### PR TITLE
Replace `expand` with `fnameescape` in mpi#get

### DIFF
--- a/mpi.vim
+++ b/mpi.vim
@@ -134,7 +134,7 @@ let g:mpi#exact_matches = {
 \}
 
 function! mpi#get(bufname) abort
-    let ext = fnamemodify(expand(a:bufname), ':e')
+    let ext = fnamemodify(fnameescape(a:bufname), ':e')
     if empty(ext)
         let l:has_key = has_key(g:mpi#exact_matches, a:bufname)
         if l:has_key


### PR DESCRIPTION
This avoids expanding a filename like [b-a] which
resulted in "E944: Reverse range in character class" error.

This happened because I was calling `mpi#get(expand('%:t'))`, meaning that `expand()` was being called twice on the filename "[b-a]", resulting in the second expand giving the error.

However, since the above command is in the README's [example](https://github.com/LinArcX/mpi#how-use-it) usage, I think it makes sense to escape the buffer name with `fnameescape`. 

`fnameescape` also expands environmental variables and most of what I understand `expand` is doing here. I have tested it for a while and had no issues, but let me know if you think there are, or if you disagree on this change entirely. Thanks for this lightweight plugin!